### PR TITLE
Fixed critical bug in SwiftUI camera + browser views

### DIFF
--- a/Sources/MediaCore/API/Extensions/PhotoKit/Dictionary+PhotoKit.swift
+++ b/Sources/MediaCore/API/Extensions/PhotoKit/Dictionary+PhotoKit.swift
@@ -31,6 +31,10 @@ extension Dictionary where Key == UIImagePickerController.InfoKey {
     ///
     public var imageURL: URL? { self[Key.imageURL] as? URL }
 
+    /// Convenience access to the UIImage in the info dictionary
+    ///
+    public var originalImage: UIImage? { self[Key.originalImage] as? UIImage }
+
     /// Convenience access to the PHLivePhoto in the info dictionary
     ///
     public var phLivePhoto: PHLivePhoto? { self[Key.livePhoto] as? PHLivePhoto }

--- a/Sources/MediaCore/API/Photo/Photo+Error.swift
+++ b/Sources/MediaCore/API/Photo/Photo+Error.swift
@@ -13,5 +13,7 @@ extension Photo {
         case couldNotCreateCIImage
         /// Thrown if a full size image URL is missing
         case missingFullSizeImageURL
+        /// Thrown if the camera produced an unsupported result
+        case unsupportedCameraResult
     }
 }

--- a/Sources/MediaCore/API/PublicAliases.swift
+++ b/Sources/MediaCore/API/PublicAliases.swift
@@ -19,7 +19,6 @@ public typealias ResultDataCompletion = (Result<Data, Swift.Error>) -> Void
 public typealias ResultGenericCompletion<T> = (Result<T, Swift.Error>) -> Void
 public typealias ResultLivePhotoCompletion = (Result<LivePhoto, Error>) -> Void
 public typealias RequestLivePhotoResultHandler = (PHLivePhoto?, [AnyHashable : Any]) -> Void
-public typealias ResultMediaURLCompletion<T: MediaProtocol> = (Result<Media.URL<T>, Swift.Error>) -> Void
 public typealias ResultPHAssetCompletion = (Result<PHAsset, Swift.Error>) -> Void
 public typealias ResultPhotoCompletion = (Result<Photo, Swift.Error>) -> Void
 public typealias ResultURLCompletion = (Result<URL, Swift.Error>) -> Void

--- a/Sources/MediaCore/API/Video/Video+Error.swift
+++ b/Sources/MediaCore/API/Video/Video+Error.swift
@@ -11,6 +11,8 @@ extension Video {
     public enum Error: Swift.Error {
         /// AVAsset is missing in the response
         case noAVAssetInResponse
+        /// Camera returned unsupported result
+        case unsupportedCameraResult
         /// Thrown if the given export preset is not supported for the current os version
         case unsupportedExportPreset
         /// Thrown if the file type of the output URL is not supported by the export session

--- a/Sources/MediaSwiftUI/API/Camera/Camera+Result.swift
+++ b/Sources/MediaSwiftUI/API/Camera/Camera+Result.swift
@@ -1,0 +1,22 @@
+//
+//  Camera+Result.swift
+//  
+//
+//  Created by Christian Elies on 22.03.20.
+//
+
+#if canImport(UIKit) && !os(tvOS)
+import UIKit
+
+@available(iOS 13, macOS 10.15, *)
+extension Camera {
+    /// Represents the results produced by a camera
+    ///
+    public enum `Result` {
+        /// A photo was taken by the camera, the associated value is a `UIImage`
+        case tookPhoto(image: UIImage)
+        /// A video was taken by the camera, the associated value is the `URL` of the video
+        case tookVideo(url: URL)
+    }
+}
+#endif

--- a/Sources/MediaSwiftUI/API/Camera/Camera.swift
+++ b/Sources/MediaSwiftUI/API/Camera/Camera.swift
@@ -14,12 +14,14 @@ import UIKit
 /// Type which provides a ready-to-use SwiftUI view
 ///
 public struct Camera {
+    public typealias ResultCameraResultCompletion = (Swift.Result<Camera.Result, Swift.Error>) -> Void
+
     /// A ready-to-use `SwiftUI` camera view which returns the URL to the
     /// captured media on `success`
     ///
-    /// - Parameter completion: a closure which gets the `Result` (`URL` to the captured media on `success` or `Error` on `failure`)
+    /// - Parameter completion: a closure which gets the `Result` (`CameraResult` on `success` or `Error` on `failure`)
     ///
-    public static func view<T: MediaProtocol>(_ completion: @escaping ResultMediaURLCompletion<T>) throws -> some View {
+    public static func view(_ completion: @escaping ResultCameraResultCompletion) throws -> some View {
         let availableMediaTypes = UIImagePickerController.availableMediaTypes(for: .camera) ?? []
         let mediaTypes = try availableMediaTypes.map { try UIImagePickerController.MediaType(string: $0) }
         return try ViewCreator.camera(for: Set(mediaTypes), completion)

--- a/Sources/MediaSwiftUI/API/Media/Media+SwiftUI.swift
+++ b/Sources/MediaSwiftUI/API/Media/Media+SwiftUI.swift
@@ -21,13 +21,15 @@ public extension Media {
             throw MediaPicker.Error.noBrowsingSourceTypeAvailable
         }
 
-        return MediaPicker(sourceType: sourceType, mediaTypes: []) { value in
+        return MediaPicker(sourceType: sourceType, mediaTypes: [], onSelection: { value in
             guard case let MediaPickerValue.selectedMedia(phAsset) = value else {
                 completion(.failure(MediaPicker.Error.unsupportedValue))
                 return
             }
             completion(.success(phAsset))
-        }
+        }, onFailure: { error in
+            completion(.failure(error))
+        })
     }
 }
 #endif

--- a/Sources/MediaSwiftUI/API/Models/Errors/MediaPicker+Error.swift
+++ b/Sources/MediaSwiftUI/API/Models/Errors/MediaPicker+Error.swift
@@ -11,6 +11,8 @@ extension MediaPicker {
     /// Errors thrown by the `MediaPicker`
     ///
     public enum Error: Swift.Error {
+        /// no value found in `UIImagePickerController` result
+        case missingValue
         /// browsing the photo library is not supported on the current device
         case noBrowsingSourceTypeAvailable
         /// picker value is not supported by the caller

--- a/Sources/MediaSwiftUI/API/Photo/Photo+Camera+Result.swift
+++ b/Sources/MediaSwiftUI/API/Photo/Photo+Camera+Result.swift
@@ -1,0 +1,26 @@
+//
+//  Photo+Camera+Result.swift
+//  
+//
+//  Created by Christian Elies on 22.03.20.
+//
+
+#if canImport(UIKit)
+import MediaCore
+import UIKit
+
+extension Photo {
+    /// Namespace for Photo camera related types
+    ///
+    public struct Camera {}
+}
+
+extension Photo.Camera {
+    /// Represents the results produced by a Photo camera
+    ///
+    public enum `Result` {
+        /// Camera captured a photo in the format of a `UIImage`
+        case tookPhoto(image: UIImage)
+    }
+}
+#endif

--- a/Sources/MediaSwiftUI/API/Photo/Photo+SwiftUI.swift
+++ b/Sources/MediaSwiftUI/API/Photo/Photo+SwiftUI.swift
@@ -12,14 +12,26 @@ import SwiftUI
 #if !os(tvOS)
 @available (iOS 13, macOS 10.15, *)
 public extension Photo {
-    typealias ResultMediaURLPhotoCompletion = (Result<Media.URL<Photo>, Swift.Error>) -> Void
+    typealias ResultPhotoCameraResultCompletion = (Result<Camera.Result, Swift.Error>) -> Void
 
     /// Creates a ready-to-use `SwiftUI` view for capturing `Photo`s
     ///
-    /// - Parameter completion: a closure which gets a `Result` (`Media.URL<Photo>` on `success` or `Error` on `failure`)
+    /// - Parameter completion: a closure which gets a `Result` (`Photo.Camera.Result` on `success` or `Error` on `failure`)
     ///
-    static func camera(_ completion: @escaping ResultMediaURLPhotoCompletion) throws -> some View {
-        try ViewCreator.camera(for: [.image], completion)
+    static func camera(_ completion: @escaping ResultPhotoCameraResultCompletion) throws -> some View {
+        try ViewCreator.camera(for: [.image]) { result in
+            switch result {
+            case .success(let cameraResult):
+                switch cameraResult {
+                case .tookPhoto(let image):
+                    completion(.success(.tookPhoto(image: image)))
+                default:
+                    completion(.failure(Photo.Error.unsupportedCameraResult))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
     }
 
     /// Creates a ready-to-use `SwiftUI` view for browsing the photo library

--- a/Sources/MediaSwiftUI/API/Video/Video+SwiftUI.swift
+++ b/Sources/MediaSwiftUI/API/Video/Video+SwiftUI.swift
@@ -31,7 +31,24 @@ public extension Video {
     /// - Parameter completion: a closure wich gets `Media.URL<Video>` on `success` or `Error` on `failure`
     ///
     static func camera(_ completion: @escaping ResultMediaURLVideoCompletion) throws -> some View {
-        try ViewCreator.camera(for: [.movie], completion)
+        try ViewCreator.camera(for: [.movie]) { result in
+            switch result {
+            case .success(let cameraResult):
+                switch cameraResult {
+                case .tookVideo(let url):
+                    do {
+                        let mediaURL = try Media.URL<Video>(url: url)
+                        completion(.success(mediaURL))
+                    } catch {
+                        completion(.failure(error))
+                    }
+                default:
+                    completion(.failure(Video.Error.unsupportedCameraResult))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
     }
 
     /// Creates a ready-to-use `SwiftUI` view for browsing `Video`s in the photo library

--- a/Sources/MediaSwiftUI/internal/Views/MediaPicker/MediaPicker+Coordinator.swift
+++ b/Sources/MediaSwiftUI/internal/Views/MediaPicker/MediaPicker+Coordinator.swift
@@ -35,6 +35,8 @@ extension MediaPicker {
 
             if let mediaPickerValue = Self.mediaPickerValue(forSourceType: picker.sourceType, mediaType: mediaType, info: info) {
                 mediaPicker.onSelection(mediaPickerValue)
+            } else {
+                mediaPicker.onFailure(.missingValue)
             }
 
             picker.dismiss(animated: true, completion: nil)
@@ -51,11 +53,11 @@ extension MediaPicker.Coordinator {
 
         switch (sourceType, mediaType) {
         case (.camera, .image):
-            guard let imageURL = info.imageURL else {
+            guard let originalImage = info.originalImage else {
                 return nil
             }
 
-            return .tookPhoto(url: imageURL)
+            return .tookPhoto(image: originalImage)
 
         case (.camera, .movie):
             guard let mediaURL = info.mediaURL else {

--- a/Sources/MediaSwiftUI/internal/Views/MediaPicker/MediaPicker.swift
+++ b/Sources/MediaSwiftUI/internal/Views/MediaPicker/MediaPicker.swift
@@ -17,6 +17,7 @@ struct MediaPicker: UIViewControllerRepresentable {
     let sourceType: UIImagePickerController.SourceType
     let mediaTypes: Set<UIImagePickerController.MediaType>
     let onSelection: (MediaPickerValue) -> Void
+    let onFailure: (MediaPicker.Error) -> Void
 
     func makeUIViewController(context: UIViewControllerRepresentableContext<MediaPicker>) -> UIImagePickerController {
         let imagePickerViewController = Self.imagePickerControllerType.init()
@@ -44,9 +45,7 @@ struct MediaPicker: UIViewControllerRepresentable {
 @available(iOS 13, macOS 10.15, *)
 struct MediaPicker_Previews: PreviewProvider {
     static var previews: some View {
-        MediaPicker(sourceType: .savedPhotosAlbum, mediaTypes: []) { value in
-
-        }
+        MediaPicker(sourceType: .savedPhotosAlbum, mediaTypes: [], onSelection: { _ in }, onFailure: { _ in })
     }
 }
 #endif

--- a/Sources/MediaSwiftUI/internal/Views/MediaPicker/MediaPickerValue.swift
+++ b/Sources/MediaSwiftUI/internal/Views/MediaPicker/MediaPickerValue.swift
@@ -5,13 +5,14 @@
 //  Created by Christian Elies on 26.11.19.
 //
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(UIKit)
 import Photos
+import UIKit
 
 @available(iOS 13, macOS 10.15, *)
 @available(tvOS, unavailable)
 enum MediaPickerValue {
-    case tookPhoto(url: URL)
+    case tookPhoto(image: UIImage)
     case tookVideo(url: URL)
     case selectedMedia(phAsset: PHAsset)
     case selectedLivePhoto(_ livePhoto: PHLivePhoto, phAsset: PHAsset)

--- a/Tests/MediaTests/Extensions/PhotoKitDictionaryTests.swift
+++ b/Tests/MediaTests/Extensions/PhotoKitDictionaryTests.swift
@@ -6,6 +6,9 @@
 //
 
 @testable import MediaCore
+#if canImport(UIKit)
+import UIKit
+#endif
 import XCTest
 
 final class PhotoKitDictionaryTests: XCTestCase {
@@ -36,6 +39,16 @@ final class PhotoKitDictionaryTests: XCTestCase {
 
         XCTAssertEqual(dictionary.imageURL, imageURL)
     }
+
+    #if canImport(UIKit)
+    func testOriginalImage() {
+        let image = UIImage()
+
+        dictionary[.originalImage] = image
+
+        XCTAssertEqual(dictionary.originalImage, image)
+    }
+    #endif
 
     func testMediaURL() {
         let mediaURL = URL(fileURLWithPath: "file://test.mov")

--- a/Tests/MediaTests/Models/Camera/CameraTests.swift
+++ b/Tests/MediaTests/Models/Camera/CameraTests.swift
@@ -14,7 +14,7 @@ final class CameraTests: XCTestCase {
     @available(iOS 13, *)
     func testView() {
         do {
-            let completion: ResultMediaURLCompletion<Photo> = { _ in }
+            let completion: Camera.ResultCameraResultCompletion = { _ in }
             _ = try Camera.view(completion)
             XCTFail("This should never happen because the simulator has no camera.")
         } catch {

--- a/Tests/MediaTests/Services/ViewCreatorTests.swift
+++ b/Tests/MediaTests/Services/ViewCreatorTests.swift
@@ -14,7 +14,7 @@ import XCTest
 final class ViewCreatorTests: XCTestCase {
     func testCreateCameraView() {
         do {
-            let completion: (Result<Media.URL<Photo>, Error>) -> Void = { result in }
+            let completion: (Result<Camera.Result, Error>) -> Void = { result in }
             _ = try ViewCreator.camera(for: [], completion)
             XCTFail("This should never happen because the simulator has no camera.")
         } catch {

--- a/Tests/MediaTests/Views/MediaPickerCoordinatorTests.swift
+++ b/Tests/MediaTests/Views/MediaPickerCoordinatorTests.swift
@@ -11,12 +11,12 @@ import XCTest
 @available(iOS 13, *)
 final class MediaPickerCoordinatorTests: XCTestCase {
     func testPhotoCameraMediaPickerValueSuccess() {
-        let imageURL = URL(fileURLWithPath: "\(FileManager.default.currentDirectoryPath)/test.jpeg")
+        let originalImage = UIImage()
 
         let mediaPickerValue = MediaPicker.Coordinator.mediaPickerValue(
             forSourceType: .camera,
             mediaType: .image,
-            info: [UIImagePickerController.InfoKey.imageURL: imageURL])
+            info: [UIImagePickerController.InfoKey.originalImage: originalImage])
         XCTAssertNotNil(mediaPickerValue)
     }
 

--- a/Tests/MediaTests/Views/MediaPickerTests.swift
+++ b/Tests/MediaTests/Views/MediaPickerTests.swift
@@ -18,10 +18,12 @@ final class MediaPickerTests: XCTestCase {
     }
 
     func testInitPhotoLibraryMediaPicker() {
-        let selection: (MediaPickerValue) -> Void = { value in }
+        let selection: (MediaPickerValue) -> Void = { _ in }
+        let onFailure: (MediaPicker.Error) -> Void = { _ in }
         _ = MediaPicker(sourceType: .photoLibrary,
                         mediaTypes: [],
-                        onSelection: selection)
+                        onSelection: selection,
+                        onFailure: onFailure)
     }
 }
 #endif


### PR DESCRIPTION
**Issue:**

The captured or selected item (photo or video) wasn't passed to the delegate.